### PR TITLE
Support for nativescript 5 and 6

### DIFF
--- a/grid-view-common.ts
+++ b/grid-view-common.ts
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 
-import { ObservableArray } from "data/observable-array";
-import { parse, parseMultipleTemplates } from "ui/builder";
-import { EventData, makeParser, makeValidator } from "ui/content-view";
-import { CSSType, CoercibleProperty, ContainerView, KeyedTemplate, Length, PercentLength, Property, Template, View } from "ui/core/view";
-import { addWeakEventListener, removeWeakEventListener } from "ui/core/weak-event-listener";
-import { Label } from "ui/label";
-import { ItemsSource } from "ui/list-view";
+import { ObservableArray } from "tns-core-modules/data/observable-array";
+import { parse, parseMultipleTemplates } from "tns-core-modules/ui/builder";
+import { EventData, makeParser, makeValidator } from "tns-core-modules/ui/content-view";
+import { CSSType, CoercibleProperty, ContainerView, KeyedTemplate, Length, PercentLength, Property, Template, View } from "tns-core-modules/ui/core/view";
+import { addWeakEventListener, removeWeakEventListener } from "tns-core-modules/ui/core/weak-event-listener";
+import { Label } from "tns-core-modules/ui/label";
+import { ItemsSource } from "tns-core-modules/ui/list-view";
 import { GridItemEventData, GridView as GridViewDefinition, Orientation } from ".";
 
 const autoEffectiveRowHeight = 100;
 const autoEffectiveColWidth = 100;
 
-export * from "ui/core/view";
+export * from "tns-core-modules/ui/core/view";
 
 // tslint:disable-next-line
 export module knownTemplates {

--- a/grid-view.android.ts
+++ b/grid-view.android.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 
-import { KeyedTemplate, Length, View } from "ui/core/view";
-import { GridLayout } from "ui/layouts/grid-layout";
-import * as utils from "utils/utils";
+import { KeyedTemplate, Length, View } from "tns-core-modules/ui/core/view";
+import { GridLayout } from "tns-core-modules/ui/layouts/grid-layout";
+import * as utils from "tns-core-modules/utils/utils";
 
 import {
     GridViewBase,

--- a/grid-view.d.ts
+++ b/grid-view.d.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 
-import { KeyedTemplate, PercentLength, Template, ContainerView } from "ui/core/view";
-import { ItemsSource, ItemEventData, TemplatedItemsView } from "ui/list-view";
-import { EventData } from "data/observable";
+import { KeyedTemplate, PercentLength, Template, ContainerView } from "tns-core-modules/ui/core/view";
+import { ItemsSource, ItemEventData, TemplatedItemsView } from "tns-core-modules/ui/list-view";
+import { EventData } from "tns-core-modules/data/observable";
 
 export type Orientation = "horizontal" | "vertical"
 

--- a/grid-view.ios.ts
+++ b/grid-view.ios.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 
-import { EventData, Observable } from "data/observable";
-import { KeyedTemplate, Length, View } from "ui/core/view";
-import * as utils from "utils/utils";
+import { EventData, Observable } from "tns-core-modules/data/observable";
+import { KeyedTemplate, Length, View } from "tns-core-modules/ui/core/view";
+import * as utils from "tns-core-modules/utils/utils";
 
 import {
     GridViewBase,


### PR DESCRIPTION
Nativescript 5.4.0 is not accepting import with relative path, only accepts import with absolute path.
    
    An error occurred while executing the command tns run ios --bundle --env.uglify --env.aot --env.report:
    
    ERROR in node_modules / nativescript-grid-view / grid-view.d.ts (17,71): error TS2307: Can not find module 'ui / core / view'.
    node_modules / nativescript-grid-view / grid-view.d.ts (18,64): error TS2307: Can not find module 'ui / list-view'.
    node_modules / nativescript-grid-view / grid-view.d.ts (19,27): error TS2307: Can not find module 'data / observable'.
    node_modules / nativescript-grid-view / angular / grid-view-comp.d.ts (20,14): error TS2416: Property 'nativeElement' in type 'GridViewComponent' is not assignable to the same 
property in base type 'TemplatedItemsComponent' .
      Property 'off' is missing in type 'GridView' but required in type 'TemplatedItemsView'.
    (21,15): error TS2416: Property 'templatedItemsView' in type 'GridViewComponent' is not assignable to the same property in base type 'TemplatedItemsComponent' .
      Type 'GridView' is not assignable to type 'TemplatedItemsView'.
    
    Fixed imports with absolute path so that the plugin is compatible with the new version of Nativescript 5 and 6.